### PR TITLE
Fix goreleaser deprecation warning.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-publish --snapshot
+          args: release --clean --skip=publish --snapshot
         env:
           BUILD_USER: ${{ github.actor }} (via Github Actions)
 


### PR DESCRIPTION
DEPRECATED: --skip-publish was deprecated in favor of --skip=publish, check https://goreleaser.com/deprecations#-skip for more details.