### PR TITLE
Improve text parser errors (standalone mode)

### DIFF
--- a/pkg/exabgp/messages/text/rib.go
+++ b/pkg/exabgp/messages/text/rib.go
@@ -27,6 +27,40 @@ var rxParseAttributeExtendedCommunity = `(?:^|\s+)extended-community (?P<extende
 var rxParseAttributeOriginatorID = `(?:^|\s+)originator-id (?P<originatorid>\S+)`
 var rxParseAttributeLocalPref = `(?:^|\s+)local-preference (?P<localpreference>\d+)`
 
+// ParseError contains details about a failed text parser match.
+type ParseError struct {
+	Parser string
+	Input  string
+	Line   int
+}
+
+func (e *ParseError) Error() string {
+	location := ""
+	if e.Line > 0 {
+		location = fmt.Sprintf(" at line %d", e.Line)
+	}
+
+	return fmt.Sprintf("%s: unable to parse input%s: %q", e.Parser, location, e.Input)
+}
+
+func newParseError(parser string, input string) *ParseError {
+	return &ParseError{
+		Parser: parser,
+		Input:  input,
+	}
+}
+
+func withParseErrorLine(err error, line int) error {
+	parseErr, ok := err.(*ParseError)
+	if !ok {
+		return err
+	}
+
+	copy := *parseErr
+	copy.Line = line
+	return &copy
+}
+
 func parseAttributes(a string) Attribute {
 	var attribute Attribute
 
@@ -116,7 +150,7 @@ func parseUnicastLine(s string) (map[string]string, error) {
 	re := regexp.MustCompile(rxParseUnicast)
 	matches := re.FindStringSubmatch(s)
 	if len(matches) == 0 {
-		return md, fmt.Errorf("unable to parse line")
+		return md, newParseError("unicast parser", s)
 	}
 	keys := re.SubexpNames()
 	if len(keys) != 0 {
@@ -134,7 +168,7 @@ func parseRIBLine(s string) (map[string]string, error) {
 	re := regexp.MustCompile(rxParseRIBLine)
 	matches := re.FindStringSubmatch(s)
 	if len(matches) == 0 {
-		return md, fmt.Errorf("unable to parse line")
+		return md, newParseError("rib parser", s)
 	}
 	keys := re.SubexpNames()
 	if len(keys) != 0 {
@@ -151,14 +185,16 @@ func parseRIBLine(s string) (map[string]string, error) {
 func RibFromBytes(b []byte) ([]*RIBMessage, error) {
 	var ribs []*RIBMessage
 	reader := bufio.NewReader(bytes.NewReader(b))
+	lineNo := 0
 	for {
 		l, _, err := reader.ReadLine()
 		if err == io.EOF {
 			break
 		}
+		lineNo++
 		r, err := RibEntryFromString(string(l))
 		if err != nil {
-			return ribs, err
+			return ribs, withParseErrorLine(err, lineNo)
 		}
 		ribs = append(ribs, r)
 	}

--- a/pkg/exabgp/messages/text/rib_test.go
+++ b/pkg/exabgp/messages/text/rib_test.go
@@ -2,8 +2,10 @@ package text
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,10 +15,10 @@ var testRibDataFile = filepath.Join("testdata", "rib-out.txt")
 
 func testGetTotalLinesInFile(t *testing.T, f string) int {
 	file, err := os.Open(f)
-	// nolint:errcheck,staticcheck
-	defer file.Close()
-
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, file.Close())
+	}()
 
 	s := bufio.NewScanner(file)
 	totalLines := 0
@@ -158,4 +160,49 @@ func TestParseIPv6UnicastNoAttributes(t *testing.T) {
 	require.Equal(t, "2001:db8:1000::/64", ipv6.NLRI)
 	require.Equal(t, "self", ipv6.NextHop)
 	require.Empty(t, ipv6.Attributes)
+}
+
+func TestRibEntryFromStringReturnsDetailedParseError(t *testing.T) {
+	_, err := RibEntryFromString("neighbor 127.0.0.1 broken")
+	require.Error(t, err)
+
+	var parseErr *ParseError
+	require.True(t, errors.As(err, &parseErr))
+	require.Equal(t, "rib parser", parseErr.Parser)
+	require.Equal(t, "neighbor 127.0.0.1 broken", parseErr.Input)
+	require.Zero(t, parseErr.Line)
+	require.Equal(t, "rib parser: unable to parse input: \"neighbor 127.0.0.1 broken\"", err.Error())
+}
+
+func TestRibFromBytesReturnsLineNumberInParseError(t *testing.T) {
+	data := strings.Join([]string{
+		"neighbor 127.0.0.1 local-ip 127.0.0.1 local-as 64496 peer-as 64496 router-id 1.1.1.1 family-allowed in-open ipv4 unicast 192.168.88.248/29 next-hop self",
+		"neighbor 127.0.0.1 broken",
+	}, "\n")
+
+	_, err := RibFromBytes([]byte(data))
+	require.Error(t, err)
+
+	var parseErr *ParseError
+	require.True(t, errors.As(err, &parseErr))
+	require.Equal(t, 2, parseErr.Line)
+	require.Contains(t, err.Error(), "at line 2")
+	require.Contains(t, err.Error(), "neighbor 127.0.0.1 broken")
+}
+
+func TestIPv4UnicastReturnsDetailedParseError(t *testing.T) {
+	m := &RIBMessage{
+		AFI:     "ipv4",
+		SAFI:    "unicast",
+		Details: "192.168.88.248/29 via self",
+	}
+
+	_, err := m.IPv4Unicast()
+	require.Error(t, err)
+
+	var parseErr *ParseError
+	require.True(t, errors.As(err, &parseErr))
+	require.Equal(t, "unicast parser", parseErr.Parser)
+	require.Equal(t, "192.168.88.248/29 via self", parseErr.Input)
+	require.Equal(t, "unicast parser: unable to parse input: \"192.168.88.248/29 via self\"", err.Error())
 }

--- a/pkg/exabgp/messages/text/status.go
+++ b/pkg/exabgp/messages/text/status.go
@@ -3,7 +3,6 @@ package text
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -22,7 +21,7 @@ func parseSummaryLine(s string) (map[string]string, error) {
 	re := regexp.MustCompile(rxSummary)
 	matches := re.FindStringSubmatch(s)
 	if len(matches) == 0 {
-		return md, fmt.Errorf("unable to parse line")
+		return md, newParseError("summary parser", s)
 	}
 	keys := re.SubexpNames()
 	if len(keys) != 0 {
@@ -62,15 +61,17 @@ func SummaryEntryFromString(s string) (*NeighborSummary, error) {
 func SummariesFromBytes(b []byte) ([]*NeighborSummary, error) {
 	var sums []*NeighborSummary
 	reader := bufio.NewReader(bytes.NewReader(b))
+	lineNo := 0
 	for {
 		l, _, err := reader.ReadLine()
 		if err == io.EOF {
 			break
 		}
+		lineNo++
 		if string(l) != summaryHeaderLine {
 			r, err := SummaryEntryFromString(string(l))
 			if err != nil {
-				return sums, err
+				return sums, withParseErrorLine(err, lineNo)
 			}
 			sums = append(sums, r)
 		}

--- a/pkg/exabgp/messages/text/status_test.go
+++ b/pkg/exabgp/messages/text/status_test.go
@@ -1,8 +1,10 @@
 package text
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,4 +33,33 @@ func TestParseSummaryDown(t *testing.T) {
 	require.Equal(t, "down", parsedEvents[0].Status)
 	require.Equal(t, "up", parsedEvents[1].Status)
 	require.Equal(t, "down", parsedEvents[2].Status)
+}
+
+func TestSummaryEntryFromStringReturnsDetailedParseError(t *testing.T) {
+	_, err := SummaryEntryFromString("127.0.0.1 broken")
+	require.Error(t, err)
+
+	var parseErr *ParseError
+	require.True(t, errors.As(err, &parseErr))
+	require.Equal(t, "summary parser", parseErr.Parser)
+	require.Equal(t, "127.0.0.1 broken", parseErr.Input)
+	require.Zero(t, parseErr.Line)
+	require.Equal(t, "summary parser: unable to parse input: \"127.0.0.1 broken\"", err.Error())
+}
+
+func TestSummariesFromBytesReturnsLineNumberInParseError(t *testing.T) {
+	data := strings.Join([]string{
+		summaryHeaderLine,
+		"127.0.0.1       64496        down idle                  0          0",
+		"127.0.0.1 broken",
+	}, "\n")
+
+	_, err := SummariesFromBytes([]byte(data))
+	require.Error(t, err)
+
+	var parseErr *ParseError
+	require.True(t, errors.As(err, &parseErr))
+	require.Equal(t, 3, parseErr.Line)
+	require.Contains(t, err.Error(), "at line 3")
+	require.Contains(t, err.Error(), "127.0.0.1 broken")
 }

--- a/pkg/exporter/standalone_exporter.go
+++ b/pkg/exporter/standalone_exporter.go
@@ -105,7 +105,6 @@ func (e *StandaloneExporter) Collect(ch chan<- prometheus.Metric) {
 				e.BaseExporter.logger.Error(
 					"unable to handle family",
 					"family", r.Family(),
-					"error", err.Error(),
 				)
 			}
 		}
@@ -139,10 +138,12 @@ func (e *StandaloneExporter) scrape(ch chan<- prometheus.Metric) ([]*text.RIBMes
 	}
 	ribs, ribserr := text.RibFromBytes(ribres)
 	if ribserr != nil {
+		e.BaseExporter.parseFailures.Inc()
 		return rs, ns, ribserr
 	}
 	return ribs, status, nil
 }
+
 func (e *StandaloneExporter) getSummary() ([]byte, error) {
 	return e.runExaBGPCLI(showSummarySubcommand)
 }


### PR DESCRIPTION
That PR replaces generic "unable to parse line" errors without any details to custom error, which shows a bad line.

I have encountered the problem of flapping "up" which i believe is caused by separate healthcheck which also calls exabgpcli.